### PR TITLE
fix nsdate serialization

### DIFF
--- a/Realm-JSONAPI.podspec
+++ b/Realm-JSONAPI.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Realm-JSONAPI"
-  s.version          = "0.1.1"
+  s.version          = "0.1.2"
   s.summary          = "Easily integrate with a JSON-API compliant server"
 
 # This description is used to generate tags and improve search results.

--- a/Realm-JSONAPI/Classes/NSDate+ISO8601.m
+++ b/Realm-JSONAPI/Classes/NSDate+ISO8601.m
@@ -22,10 +22,10 @@
   struct tm *timeinfo;
   char buffer[80];
 
-  time_t rawtime = [self timeIntervalSince1970] - [[NSTimeZone localTimeZone] secondsFromGMT];
-  timeinfo = localtime(&rawtime);
+  time_t rawtime = [self timeIntervalSince1970];
+  timeinfo = gmtime(&rawtime);
 
-  strftime(buffer, 80, "%Y-%m-%dT%H:%M:%S%z", timeinfo);
+  strftime(buffer, 80, "%Y-%m-%dT%H:%M:%SZ", timeinfo);
 
   return [NSString stringWithCString:buffer encoding:NSUTF8StringEncoding];
 }


### PR DESCRIPTION
we were both manually adjusting the secondsFromEpoch and using the device's local time zone when serializing a date to an NSString

paired with @21echoes for review
